### PR TITLE
Fix flake8 and style issues across Python modules

### DIFF
--- a/just_intonation.py
+++ b/just_intonation.py
@@ -834,7 +834,7 @@ class Chord():
     4th note of what scale?)
     """
 
-    def __init__(self, *args):
+    def __init__(self, *args):  # noqa: C901
         """
         Construct a musical chord from a series of intervals relative to
         the root.

--- a/midi_play.py
+++ b/midi_play.py
@@ -9,7 +9,6 @@ and then play them all at once
 
 from __future__ import division, print_function
 import time
-from fractions import Fraction
 from threading import Timer  # :D
 
 # modded for pitch bend: https://github.com/endolith/pygame/blob/master/lib/midi.py
@@ -18,18 +17,20 @@ from pygame import midi
 import random
 import math
 from numpy import arange
-from numpy.random import randint
-from just_intonation import (Interval, Pitch, Chord, P1, m2, M2, m3, M3,
-                             P4, P5, m6, M6, m7, M7, P8)
+from just_intonation import Interval, Pitch, Chord, m3, M3, P4, P5, P8
+
 
 rest = 0.5  # seconds
+
 
 def log2(x):
     return math.log(x, 2)
 
+
 def freq_to_MIDI(freq):
     A = 440
     return 12 * log2(freq / A) + 69
+
 
 midi.init()
 
@@ -47,6 +48,7 @@ else:
 
 channels = 16
 program = 0
+
 
 def play_freq(freq, duration=None, sustain=15):
     """
@@ -84,6 +86,7 @@ def play_freq(freq, duration=None, sustain=15):
         # Randomize by 10% so they don't all shut off at once
         rand = random.uniform(0.9, 1.1)
         Timer(sustain*rand, synth.note_off, (MIDI_note, 0, channel)).start()
+
 
 play_freq.channel = 0
 
@@ -158,6 +161,7 @@ def play_seq(pitch, intervals, rest=rest):
         play_freq(root + x)
         time.sleep(rest)
 
+
 pitch = Pitch(110)
 
 # Lydian mode
@@ -182,6 +186,7 @@ def equal_major():
 #    for note in [57, 61, 64]:
 #        synth.note_on(note, 127, 0)
 #        Timer(5, synth.note_off, (note, 0, 0)).start()
+
 
 def just_major():
     play_freq(Pitch(220), sustain=5)

--- a/test_just_intonation.py
+++ b/test_just_intonation.py
@@ -29,7 +29,7 @@ def test_gpf():
         _gpf(-1)
 
 
-def test_interval():
+def test_interval():  # noqa: C901
     # Construction
     assert Interval(3, 2) == Interval(3, 2)
     assert Interval('P5') == Interval(3, 2)
@@ -249,10 +249,10 @@ def test_interval():
         assert round(Interval(frac).tenney_height - tenney, 3) == 0
 
     # https://en.xen.wiki/w/Tenney_height
-    for frac, ket, tenney in (('1/1', '|0>',        0           ),
-                              ('2/1', '|1>',        1           ),
-                              ('3/2', '|-1 1>',     2.5849625007),
-                              ('5/4', '|-2 0 1>',   4.3219280948),
+    for frac, ket, tenney in (('1/1', '|0>', 0),
+                              ('2/1', '|1>', 1),
+                              ('3/2', '|-1 1>', 2.5849625007),
+                              ('5/4', '|-2 0 1>', 4.3219280948),
                               ('7/4', '|-2 0 0 1>', 4.8073549220),):
         assert round(Interval(frac).tenney_height - tenney, 8) == 0
 
@@ -261,8 +261,7 @@ def test_interval():
                        ('108/77',  108),
                        ('10/7',     10),
                        ('289/288', 289),
-
-                        # Also some with larger denominator
+                       # Also some with larger denominator
                        ('2/3', 3),
                        ('1/4', 4)):
         assert Interval(frac).weil_height == weil
@@ -370,7 +369,7 @@ def test_chord():
     assert Chord('1-5/4-3/2-5/3') == Chord(12, 15, 18, 20)
     assert Chord('1/1 – 5/4 – 3/2') == Chord(4, 5, 6)
     assert Chord('1:3:5:7:9') == Chord(1, 3, 5, 7, 9)  # otonal
-    assert Chord('1/9:1/7:1/5:1/3:1/1') == Chord(35, 45, 63, 105, 315) # utonal
+    assert Chord('1/9:1/7:1/5:1/3:1/1') == Chord(35, 45, 63, 105, 315)  # utonal
     assert Chord('3/2', '4/3') == Chord(6, 8, 9)
     assert Chord('4/3', '3/2') == Chord(6, 8, 9)
     assert Chord(('3:2'), 2) == Chord(2, 3, 4)
@@ -453,5 +452,4 @@ if __name__ == "__main__":
     # TODO: this is screwing up IPython's _
 
     # Test assertions
-    import pytest
     pytest.main(['--tb=short', __file__])


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

CI runs flake8 (including undefined-name checks) and pytest. This branch cleans up everything flake8 reported on the current tree so local and CI runs stay green.

## Changes

- **midi_play.py**: Removed unused imports (`Fraction`, `randint`, and several unused `just_intonation` symbols). Kept only `Interval`, `Pitch`, `Chord`, `m3`, `M3`, `P4`, `P5`, and `P8`. Added the blank lines PEP 8 expects between top-level definitions.
- **test_just_intonation.py**: Removed trailing whitespace before closing parentheses in the Tenney-height loop; aligned the Weil-height continuation block; two spaces before the `# utonal` inline comment; dropped the redundant `import pytest` inside `__main__` (fixes F811). Added `# noqa: C901` on `test_interval` because splitting that test would be a large behavioral-no-op refactor.
- **just_intonation.py**: Added `# noqa: C901` on `Chord.__init__` for the same reason (large branching constructor).

## Verification

- `python3 -m flake8 .` (full ruleset used in CI’s second step, without `exit-zero`) — 0 issues
- `pytest` — 21 passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c91acb39-acee-4ed2-820c-85d0f7752589"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c91acb39-acee-4ed2-820c-85d0f7752589"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

