### PR TITLE
Fix OO operator protocols (NotImplemented, type checks, hash)

### DIFF
--- a/just_intonation.py
+++ b/just_intonation.py
@@ -266,7 +266,6 @@ class Interval(object):
         g = _gcd(numerator, denominator)
         self._numerator = numerator // g
         self._denominator = denominator // g
-        self._terms = self._denominator, self._numerator
 
     @property
     def numerator(a):
@@ -414,6 +413,7 @@ class Interval(object):
         """
         if isinstance(b, Interval):
             return Interval(_F(a) * _F(b))
+        return NotImplemented
 
     def __sub__(a, b):
         """
@@ -422,6 +422,7 @@ class Interval(object):
         """
         if isinstance(b, Interval):
             return Interval(_F(a) / _F(b))
+        return NotImplemented
 
     def __mul__(a, b):
         """
@@ -552,26 +553,33 @@ class Interval(object):
 
     def __eq__(a, b):
         """a == b"""
-        if isinstance(b, Interval):
-            return (a._numerator == b.numerator and
-                    a._denominator == b.denominator)
-        else:
-            return False  # TODO: or NotImplemented??
+        if not isinstance(b, Interval):
+            return NotImplemented
+        return (a._numerator == b.numerator and
+                a._denominator == b.denominator)
 
     def __lt__(a, b):
         """a < b"""
+        if not isinstance(b, Interval):
+            return NotImplemented
         return _F(a) < _F(b)
 
     def __gt__(a, b):
         """a > b"""
+        if not isinstance(b, Interval):
+            return NotImplemented
         return _F(a) > _F(b)
 
     def __le__(a, b):
         """a <= b"""
+        if not isinstance(b, Interval):
+            return NotImplemented
         return _F(a) <= _F(b)
 
     def __ge__(a, b):
         """a >= b"""
+        if not isinstance(b, Interval):
+            return NotImplemented
         return _F(a) >= _F(b)
 
     def __bool__(a):
@@ -647,7 +655,7 @@ class Pitch(object):
             self._frequency = Fraction(frequency)
 
         if int(self._frequency) == self._frequency:
-            self._frequency = int(frequency)
+            self._frequency = int(self._frequency)
 
         if self._frequency < 0:
             raise ValueError('Pitch frequency cannot be negative')
@@ -699,19 +707,27 @@ class Pitch(object):
 
     def __lt__(a, b):
         """a < b"""
-        return a._frequency < b.frequency
+        if not isinstance(b, Pitch):
+            return NotImplemented
+        return a._frequency < b._frequency
 
     def __gt__(a, b):
         """a > b"""
-        return a._frequency > b.frequency
+        if not isinstance(b, Pitch):
+            return NotImplemented
+        return a._frequency > b._frequency
 
     def __le__(a, b):
         """a <= b"""
-        return a._frequency <= b.frequency
+        if not isinstance(b, Pitch):
+            return NotImplemented
+        return a._frequency <= b._frequency
 
     def __ge__(a, b):
         """a >= b"""
-        return a._frequency >= b.frequency
+        if not isinstance(b, Pitch):
+            return NotImplemented
+        return a._frequency >= b._frequency
 
     def __bool__(a):
         """a != 0"""
@@ -723,7 +739,12 @@ class Pitch(object):
 
     def __eq__(a, b):
         """a == b"""
-        return (a._frequency == b.frequency)
+        if not isinstance(b, Pitch):
+            return NotImplemented
+        return a._frequency == b._frequency
+
+    def __hash__(self):
+        return hash(self._frequency)
 
     def __int__(a):
         """int(a)"""
@@ -734,7 +755,7 @@ class Pitch(object):
         return float(a._frequency)
 
 
-class Chord():
+class Chord:
     """
     A combination of notes separated by just intervals.
 
@@ -1069,8 +1090,12 @@ class Chord():
         >>> Chord(4, 6, 8) == Chord(2, 3, 4)
         True
         """
-        # TODO: is this ok?  or only public properties?
-        return (a._terms == b._terms)
+        if not isinstance(b, Chord):
+            return NotImplemented
+        return a._terms == b._terms
+
+    def __hash__(self):
+        return hash(self._terms)
 
     def __neg__(a):
         """

--- a/test_just_intonation.py
+++ b/test_just_intonation.py
@@ -355,7 +355,7 @@ def test_chord():
     assert Chord(Interval('3:2'), Interval(2)) == Chord(2, 3, 4)
     assert Chord(Interval('M3'), Interval('m3')) == Chord(20, 24, 25)
     assert Chord(M3) == Chord(4, 5)
-    assert Chord(M3) == Interval(5, 4)  # Is this ok?
+    assert Chord(M3) != Interval(5, 4)
     assert Chord(M3, m3) == Chord(20, 24, 25)
     assert Chord(M3, P5) == Chord(4, 5, 6)
     assert Chord(P5, M3) == Chord(4, 5, 6)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This addresses **object-oriented / dunder-method** issues in `just_intonation.py`: correct use of `NotImplemented`, type checks before touching the RHS, removal of dead state that caused misleading equality, and `__hash__` where `__eq__` is defined.

## Issues fixed

1. **`Interval.__add__` / `__sub__`**  
   When the right-hand side was not an `Interval`, these methods fell off the end and returned **`None`**, which breaks the numeric protocol and can surface as confusing `TypeError`s. They now return **`NotImplemented`**.

2. **`Interval` rich comparisons and `__eq__`**  
   `__lt__` / `__gt__` / `__le__` / `__ge__` called `_F(b)` for arbitrary `b`, which could **`AttributeError`** (e.g. `Interval(2, 1) < 2`). They now require **`isinstance(b, Interval)`** and otherwise return **`NotImplemented`**.  
   **`__eq__`** now returns **`NotImplemented`** for non-`Interval` operands so reflexive equality is handled correctly instead of blindly returning `False`.

3. **`Interval._terms`**  
   It was only set on one constructor path, was **never read** anywhere in the repo, and happened to make **`Chord(M3) == Interval(5, 4)`** true in tests by accidental tuple equality. That assignment was **removed** so `Interval` does not carry misleading private state.

4. **`Pitch.__init__`**  
   After normalizing frequency, integral values were stored with **`int(frequency)`** (the original argument) instead of the coerced value. It now uses **`int(self._frequency)`**, which is correct when `frequency` is already a `Pitch` or other wrapped type.

5. **`Pitch` ordering and `__eq__`**  
   Same pattern as `Interval`: **`isinstance(b, Pitch)`** and **`NotImplemented`** instead of **`b.frequency`** on arbitrary objects.

6. **`Pitch.__hash__`**  
   With **`__eq__`** overridden, defining **`__hash__`** keeps hashing behavior explicit and consistent with equality (based on stored frequency).

7. **`Chord`**  
   **`class Chord():`** → **`class Chord:`**. **`__eq__`** now checks **`isinstance(b, Chord)`** and returns **`NotImplemented`** otherwise (avoids **`AttributeError`** on **`b._terms`**). **`__hash__`** added so chords can be used in sets/dicts like intervals.

## Test change

- **`Chord(M3) == Interval(5, 4)`** was only true because of the removed **`Interval._terms`** quirk. The test now asserts **`Chord(M3) != Interval(5, 4)`**, which matches type-safe equality.

## Verification

- `pytest` (full suite): 21 passed  
- `pytest --doctest-modules just_intonation.py`: 17 passed  
- `flake8` (syntax/undefined-name select on touched files): clean
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c91acb39-acee-4ed2-820c-85d0f7752589"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c91acb39-acee-4ed2-820c-85d0f7752589"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

