### PR TITLE
midi_play: switch from pygame to mido + RtMidi

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,111 @@ One possibility is to install with pip from GitHub:
 
     pip install git+https://github.com/endolith/just_intonation.git
 
+## MIDI playback (`midi_play.py`)
+
+`midi_play.py` is a small **demo / scratchpad**, not part of the installable
+`just_intonation` package. It sends notes to a **MIDI output device** using
+[pygame](https://www.pygame.org/)’s PortMidi wrapper. It does **not** produce
+audio by itself: you need a **second program** (a DAW, standalone synth, or
+similar) that listens on the **other end** of a **virtual MIDI cable**.
+
+Rough signal path:
+
+```text
+midi_play.py  --MIDI-->  virtual cable  --MIDI-->  softsynth / DAW  -->  audio
+```
+
+### Why setup is fiddly
+
+* The script used to assume **device id `3`** and a name containing **`LoopBe`**. That breaks as soon as you plug in a different USB interface or reorder drivers. It now **scans** output devices by default (see environment variables below).
+* **Pitch bend** is per **MIDI channel**. The script cycles channels so chords stay bent independently; channel **10** (GM drums) is skipped.
+* You must hear the **same synth** that receives the cable. If nothing is routed to the cable’s **input** side, you get silence even though the script runs.
+
+### Dependencies
+
+```bash
+pip install pygame numpy
+```
+
+(`numpy` is only used for mode arrays at import time.)
+
+### Windows — LoopBe1 or loopMIDI
+
+1. Install a virtual MIDI driver, for example **[LoopBe1](https://www.tobias-erichsen.de/software/loopbe1.html)** (free for non‑commercial use) or **loopMIDI** from the same author.
+2. After installation you should see an **output** port in Windows whose name contains `LoopBe` (e.g. **“LoopBe Internal MIDI”**). `midi_play.py` looks for that substring by default.
+3. Open your **synthesizer** (Reaper, Ableton, standalone VST host, etc.) and set its **MIDI input** to that **same** LoopBe / loopMIDI port (the “other end” of the cable).
+4. Run Python from the repo root so `just_intonation` imports correctly, e.g.:
+
+   ```bash
+   python -i midi_play.py
+   ```
+
+   Then call `just_major()`, `play_chord(...)`, etc. in the REPL.
+
+### macOS — IAC Driver
+
+1. Open **Audio MIDI Setup** → **Window** → **Show MIDI Studio** → double‑click **IAC Driver** → enable **“Device is online”** and at least one **port** (e.g. **Bus 1**).
+2. Point your synth’s **MIDI input** at that IAC bus.
+3. Set a match substring for this script, for example:
+
+   ```bash
+   export JUST_INTONATION_MIDI_OUT_NAME=IAC
+   python -i midi_play.py
+   ```
+
+### Linux — ALSA virtual port + `aconnect`
+
+Typical pattern: create a writable **MIDI Through** or **virmidi** port, run
+**FluidSynth** / **TiMidity++** / etc., then connect with **`aconnect`**:
+
+```bash
+# Example: FluidSynth with ALSA; names vary by distro / args.
+fluidsynth -a alsa -m alsa_seq /path/to/soundfont.sf2 &
+python -i midi_play.py &
+# List clients, then connect pygame’s output client to FluidSynth’s input:
+aconnect -l
+aconnect <pygame_sender> <fluidsynth_receiver>
+```
+
+Exact client numbers change every run; use `aconnect -l` after starting both
+ends. If pygame lists **“Midi Through Port-0”** as an output, you can try:
+
+```bash
+export JUST_INTONATION_MIDI_OUT_NAME="Midi Through"
+```
+
+…and wire the other program accordingly (some setups route **Through**
+between apps; others need **virmidi** — see your distro’s MIDI how‑tos).
+
+### Choosing the device from Python
+
+If auto‑detection picks the wrong port:
+
+1. Run once without fixing anything; the **`RuntimeError`** lists **all** MIDI
+   **output** devices pygame sees, with numeric ids.
+2. Pin the id:
+
+   ```bash
+   export JUST_INTONATION_MIDI_DEVICE_ID=5
+   python -i midi_play.py
+   ```
+
+3. Or match a unique substring of the port name (case‑insensitive):
+
+   ```bash
+   export JUST_INTONATION_MIDI_OUT_NAME=loopmidi
+   ```
+
+PortMidi also supports **`PM_RECOMMENDED_OUTPUT_DEVICE`** (integer id or
+registry / env hints); see [pygame’s midi docs](https://www.pygame.org/docs/ref/midi.html).
+
+### Pitch‑bend detail
+
+The script rounds each frequency to the nearest **MIDI note number**, then
+applies a **pitch wheel** offset for the remaining fraction of a semitone.
+Your synth should use the **default** bend range (**±2 semitones**); if it is
+configured differently, bends will sound wrong.
+
 ## Examples
 
 * [Everything is a power chord in just intonation](https://soundcloud.com/endolith/everything-is-a-power-chord-in-just-intonation) - Dyads made from the harmonic series, first in piano, then undistorted guitar, then distorted guitar.

--- a/README.md
+++ b/README.md
@@ -66,10 +66,11 @@ One possibility is to install with pip from GitHub:
 ## MIDI playback (`midi_play.py`)
 
 `midi_play.py` is a small **demo / scratchpad**, not part of the installable
-`just_intonation` package. It sends notes to a **MIDI output device** using
-[pygame](https://www.pygame.org/)’s PortMidi wrapper. It does **not** produce
-audio by itself: you need a **second program** (a DAW, standalone synth, or
-similar) that listens on the **other end** of a **virtual MIDI cable**.
+`just_intonation` package. It sends notes to a **MIDI output port** using
+[mido](https://mido.readthedocs.io/) with the **[RtMidi](https://www.music.mcgill.ca/~gary/rtmidi/)**
+backend (`python-rtmidi`). It does **not** produce audio by itself: you need a
+**second program** (a DAW, standalone synth, or similar) that listens on the
+**other end** of a **virtual MIDI cable**.
 
 Rough signal path:
 
@@ -79,17 +80,19 @@ midi_play.py  --MIDI-->  virtual cable  --MIDI-->  softsynth / DAW  -->  audio
 
 ### Why setup is fiddly
 
-* The script used to assume **device id `3`** and a name containing **`LoopBe`**. That breaks as soon as you plug in a different USB interface or reorder drivers. It now **scans** output devices by default (see environment variables below).
+* The script used to assume **device id `3`** (pygame / PortMidi) and a name containing **`LoopBe`**. Port and index order still change when drivers or USB gear change; it now **scans** RtMidi output port **names** by default (see environment variables below).
 * **Pitch bend** is per **MIDI channel**. The script cycles channels so chords stay bent independently; channel **10** (GM drums) is skipped.
 * You must hear the **same synth** that receives the cable. If nothing is routed to the cable’s **input** side, you get silence even though the script runs.
 
 ### Dependencies
 
 ```bash
-pip install pygame numpy
+pip install -r requirements-midi.txt
 ```
 
-(`numpy` is only used for mode arrays at import time.)
+That installs **mido** with the **RtMidi** port driver and **numpy** (only used
+for the `lydian` / `locrian` mode arrays at import time). The main library and
+CI tests do not require these packages.
 
 ### Windows — LoopBe1 or loopMIDI
 
@@ -124,13 +127,13 @@ Typical pattern: create a writable **MIDI Through** or **virmidi** port, run
 # Example: FluidSynth with ALSA; names vary by distro / args.
 fluidsynth -a alsa -m alsa_seq /path/to/soundfont.sf2 &
 python -i midi_play.py &
-# List clients, then connect pygame’s output client to FluidSynth’s input:
+# List clients, then connect this script’s MIDI output client to FluidSynth:
 aconnect -l
 aconnect <pygame_sender> <fluidsynth_receiver>
 ```
 
 Exact client numbers change every run; use `aconnect -l` after starting both
-ends. If pygame lists **“Midi Through Port-0”** as an output, you can try:
+ends. If `mido.get_output_names()` lists **“Midi Through Port-0”** as an output, you can try:
 
 ```bash
 export JUST_INTONATION_MIDI_OUT_NAME="Midi Through"
@@ -144,7 +147,7 @@ between apps; others need **virmidi** — see your distro’s MIDI how‑tos).
 If auto‑detection picks the wrong port:
 
 1. Run once without fixing anything; the **`RuntimeError`** lists **all** MIDI
-   **output** devices pygame sees, with numeric ids.
+   **output** port names mido sees, with numeric indices.
 2. Pin the id:
 
    ```bash
@@ -158,8 +161,8 @@ If auto‑detection picks the wrong port:
    export JUST_INTONATION_MIDI_OUT_NAME=loopmidi
    ```
 
-PortMidi also supports **`PM_RECOMMENDED_OUTPUT_DEVICE`** (integer id or
-registry / env hints); see [pygame’s midi docs](https://www.pygame.org/docs/ref/midi.html).
+Other backends (PortMidi, etc.) are available in mido but not used by this
+script; see [mido backends](https://mido.readthedocs.io/en/stable/backends/index.html).
 
 ### Pitch‑bend detail
 
@@ -167,6 +170,9 @@ The script rounds each frequency to the nearest **MIDI note number**, then
 applies a **pitch wheel** offset for the remaining fraction of a semitone.
 Your synth should use the **default** bend range (**±2 semitones**); if it is
 configured differently, bends will sound wrong.
+
+(Earlier versions of this demo used **pygame** / PortMidi; pitch bend support
+landed upstream in pygame after [PR #394](https://github.com/pygame/pygame/pull/394).)
 
 ## Examples
 

--- a/midi_play.py
+++ b/midi_play.py
@@ -6,95 +6,87 @@ Each note uses its own MIDI channel so polyphony can stay in tune: the
 script picks the nearest MIDI note number and applies a small pitch-bend
 offset for the remaining cents.
 
-This module expects a *virtual MIDI cable* (or similar) as the PortMidi /
-pygame output device. You send MIDI from this script into the cable, and a
-separate synthesizer program listens on the other end of the cable.
+MIDI I/O uses `mido` with the **RtMidi** backend (`pip install mido[ports-rtmidi]`).
+You send messages from this script into a *virtual MIDI cable* (or similar),
+and a separate synthesizer listens on the other end.
 
-See the "MIDI playback" section in README.md for setup (LoopBe, loopMIDI,
-Linux ALSA routing, environment variables).
+See README.md (MIDI playback) for LoopBe / IAC / Linux routing and the
+``JUST_INTONATION_*`` environment variables.
 """
 
 from __future__ import division, print_function
 
+import atexit
 import os
 import time
 import random
 import math
 from threading import Timer
 
-# modded for pitch bend: https://github.com/endolith/pygame/blob/master/lib/midi.py
-from pygame import midi
+import mido
+
+mido.set_backend('mido.backends.rtmidi')
+
 from numpy import arange
 
 from just_intonation import Interval, Pitch, Chord, m3, M3, P4, P5, P8
 
 
-def _midi_device_name(device_info):
-    """Return a Unicode device name; pygame may give bytes on some platforms."""
-    name = device_info[1]
-    if isinstance(name, bytes):
-        return name.decode('utf-8', errors='replace')
-    return str(name)
+def _list_midi_output_names():
+    """Return output port names (RtMidi / mido order)."""
+    try:
+        return list(mido.get_output_names())
+    except Exception as exc:
+        raise RuntimeError(
+            'Could not list MIDI output ports (RtMidi failed during '
+            'enumeration). On Linux, ensure the ALSA sequencer is available '
+            '(often /dev/snd/seq) and ALSA MIDI packages are installed. '
+            'Original error:\n%s' % (exc,)) from exc
 
 
-def _list_midi_output_devices():
-    """Yield (device_id, name) for each PortMidi output device."""
-    for device_id in range(midi.get_count()):
-        info = midi.get_device_info(device_id)
-        if info is None:
-            continue
-        _interf, _name, is_input, is_output, _opened = info
-        if is_output:
-            yield device_id, _midi_device_name(info)
-
-
-def resolve_midi_output_device_id():
+def resolve_midi_output_port_name():
     """
-    Pick the pygame / PortMidi output device used by this script.
+    Return the name of the MIDI output port to open.
 
-    Resolution order:
-
-    1. If the environment variable ``JUST_INTONATION_MIDI_DEVICE_ID`` is set
-       to an integer, use that device id (must be an output device).
-    2. Otherwise scan outputs whose name contains the substring from
+    1. If ``JUST_INTONATION_MIDI_DEVICE_ID`` is set, treat it as a 0-based
+       index into ``mido.get_output_names()``.
+    2. Otherwise pick the first output whose name contains
        ``JUST_INTONATION_MIDI_OUT_NAME`` (default: ``loopbe``, case-insensitive).
-       This matches Windows *LoopBe1* ports ("LoopBe Internal MIDI", etc.).
     """
+    names = _list_midi_output_names()
     if 'JUST_INTONATION_MIDI_DEVICE_ID' in os.environ:
         device_id = int(os.environ['JUST_INTONATION_MIDI_DEVICE_ID'])
-        info = midi.get_device_info(device_id)
-        if info is None:
+        if device_id < 0 or device_id >= len(names):
             raise RuntimeError(
                 'JUST_INTONATION_MIDI_DEVICE_ID=%s is out of range '
-                '(midi.get_count() == %s).' % (device_id, midi.get_count()))
-        if not info[3]:
-            raise RuntimeError(
-                'JUST_INTONATION_MIDI_DEVICE_ID=%s is not a MIDI output.' % (
-                    device_id,))
-        return device_id
+                '(there are %s output ports).' % (device_id, len(names)))
+        return names[device_id]
 
     needle = os.environ.get(
         'JUST_INTONATION_MIDI_OUT_NAME', 'loopbe').lower()
-    outputs = list(_list_midi_output_devices())
-    for device_id, name in outputs:
+    for name in names:
         if needle in name.lower():
-            return device_id
+            return name
 
-    lines = ['No MIDI output device name contains %r.' % needle,
-             'Install a virtual MIDI cable (see README.md), then either',
-             '  set JUST_INTONATION_MIDI_OUT_NAME to a unique substring of',
-             '  its port name, or set JUST_INTONATION_MIDI_DEVICE_ID to a',
-             '  number from the list below.',
-             '',
-             'Available MIDI *output* devices:']
-    if not outputs:
-        lines.append('  (none — PortMidi sees no writable outputs; on Linux'
-                      ' check ALSA `seq` / `snd_seq` and that pygame was built'
-                      ' with MIDI support.)')
+    lines = [
+        'No MIDI output port name contains %r.' % needle,
+        'Install a virtual MIDI cable (see README.md), then either set',
+        'JUST_INTONATION_MIDI_OUT_NAME to a substring of the port name, or',
+        'JUST_INTONATION_MIDI_DEVICE_ID to an index from the list below.',
+        '',
+        'Available MIDI output ports (mido / RtMidi):',
+    ]
+    if not names:
+        lines.append(
+            '  (none — install python-rtmidi / ALSA seq as needed; see README.)')
     else:
-        for device_id, name in outputs:
-            lines.append('  %s: %s' % (device_id, name))
+        for i, name in enumerate(names):
+            lines.append('  %s: %s' % (i, name))
     raise RuntimeError('\n'.join(lines))
+
+
+def _clip_pitchwheel(value):
+    return max(mido.MIN_PITCHWHEEL, min(mido.MAX_PITCHWHEEL, int(value)))
 
 
 rest = 0.5  # seconds
@@ -109,14 +101,9 @@ def freq_to_MIDI(freq):
     return 12 * log2(freq / A) + 69
 
 
-midi.init()
-
-_output_id = resolve_midi_output_device_id()
-try:
-    synth = midi.Output(_output_id)
-except Exception:
-    midi.quit()
-    raise
+_midi_port_name = resolve_midi_output_port_name()
+midi_port = mido.open_output(_midi_port_name)
+atexit.register(midi_port.close)
 
 channels = 16
 program = 0
@@ -134,7 +121,7 @@ def play_freq(freq, duration=None, sustain=15):
     MIDI_float = freq_to_MIDI(float(freq))
     MIDI_note = int(round(MIDI_float))
     frac = MIDI_float - MIDI_note
-    bend_amount = int(frac * 4096)
+    bend_amount = _clip_pitchwheel(frac * 4096)
 
     channel = play_freq.channel
     play_freq.channel += 1
@@ -146,18 +133,27 @@ def play_freq(freq, duration=None, sustain=15):
         play_freq.channel += 1
         play_freq.channel %= channels
 
-    synth.set_instrument(program, channel)
-    synth.pitch_bend(bend_amount, channel)
+    midi_port.send(mido.Message(
+        'program_change', channel=channel, program=program))
+    midi_port.send(mido.Message(
+        'pitchwheel', channel=channel, pitch=bend_amount))
     velocity = random.randint(110, 127)  # Humanize
-    synth.note_on(MIDI_note, velocity, channel)
+    midi_port.send(mido.Message(
+        'note_on', channel=channel, note=MIDI_note, velocity=velocity))
     if duration is not None:
         time.sleep(duration)
-        synth.note_off(MIDI_note, 0, channel)
+        midi_port.send(mido.Message(
+            'note_off', channel=channel, note=MIDI_note, velocity=0))
     else:
         # Prevents synth from choking on all the tails of notes
         # Randomize by 10% so they don't all shut off at once
         rand = random.uniform(0.9, 1.1)
-        Timer(sustain * rand, synth.note_off, (MIDI_note, 0, channel)).start()
+
+        def _note_off():
+            midi_port.send(mido.Message(
+                'note_off', channel=channel, note=MIDI_note, velocity=0))
+
+        Timer(sustain * rand, _note_off).start()
 
 
 play_freq.channel = 0
@@ -247,17 +243,15 @@ locrian = sorted(arange(7) * P4 % P8) + [P8]
 
 # Equal:
 def equal_major():
-    synth.set_instrument(program, channel=0)
-    synth.pitch_bend(0, channel=0)
+    midi_port.send(mido.Message(
+        'program_change', channel=0, program=program))
+    midi_port.send(mido.Message('pitchwheel', channel=0, pitch=0))
     for note in [57, 61, 64]:
-        synth.note_on(note, 127, 0)
-        Timer(5, synth.note_off, (note, 0, 0)).start()
+        midi_port.send(mido.Message(
+            'note_on', channel=0, note=note, velocity=127))
+        Timer(5, lambda n=note: midi_port.send(mido.Message(
+            'note_off', channel=0, note=n, velocity=0))).start()
         time.sleep(1)
-#    synth.set_instrument(program,channel=1)
-#    synth.pitch_bend(channel=1)
-#    for note in [57, 61, 64]:
-#        synth.note_on(note, 127, 0)
-#        Timer(5, synth.note_off, (note, 0, 0)).start()
 
 
 def just_major():
@@ -271,11 +265,14 @@ def just_major():
 
 
 def equal_minor():
-    synth.set_instrument(program, channel=0)
-    synth.pitch_bend(0, channel=0)
+    midi_port.send(mido.Message(
+        'program_change', channel=0, program=program))
+    midi_port.send(mido.Message('pitchwheel', channel=0, pitch=0))
     for note in [57, 60, 64]:
-        synth.note_on(note, 127, 0)
-        Timer(5, synth.note_off, (note, 0, 0)).start()
+        midi_port.send(mido.Message(
+            'note_on', channel=0, note=note, velocity=127))
+        Timer(5, lambda n=note: midi_port.send(mido.Message(
+            'note_off', channel=0, note=n, velocity=0))).start()
         time.sleep(1)
 
 

--- a/midi_play.py
+++ b/midi_play.py
@@ -1,52 +1,126 @@
 # -*- coding: utf-8 -*-
 """
-Created on Tue Aug 26 22:27:10 2014
+Play just-intonation material over MIDI using pitch bend.
 
-So to play MIDI chords, put each note on its
-own channel, pitch bend them by less than one semitone to correct the pitch
-and then play them all at once
+Each note uses its own MIDI channel so polyphony can stay in tune: the
+script picks the nearest MIDI note number and applies a small pitch-bend
+offset for the remaining cents.
+
+This module expects a *virtual MIDI cable* (or similar) as the PortMidi /
+pygame output device. You send MIDI from this script into the cable, and a
+separate synthesizer program listens on the other end of the cable.
+
+See the "MIDI playback" section in README.md for setup (LoopBe, loopMIDI,
+Linux ALSA routing, environment variables).
 """
 
 from __future__ import division, print_function
+
+import os
 import time
-from fractions import Fraction
-from threading import Timer  # :D
+import random
+import math
+from threading import Timer
 
 # modded for pitch bend: https://github.com/endolith/pygame/blob/master/lib/midi.py
 from pygame import midi
-
-import random
-import math
 from numpy import arange
-from numpy.random import randint
-from just_intonation import (Interval, Pitch, Chord, P1, m2, M2, m3, M3,
-                             P4, P5, m6, M6, m7, M7, P8)
+
+from just_intonation import Interval, Pitch, Chord, m3, M3, P4, P5, P8
+
+
+def _midi_device_name(device_info):
+    """Return a Unicode device name; pygame may give bytes on some platforms."""
+    name = device_info[1]
+    if isinstance(name, bytes):
+        return name.decode('utf-8', errors='replace')
+    return str(name)
+
+
+def _list_midi_output_devices():
+    """Yield (device_id, name) for each PortMidi output device."""
+    for device_id in range(midi.get_count()):
+        info = midi.get_device_info(device_id)
+        if info is None:
+            continue
+        _interf, _name, is_input, is_output, _opened = info
+        if is_output:
+            yield device_id, _midi_device_name(info)
+
+
+def resolve_midi_output_device_id():
+    """
+    Pick the pygame / PortMidi output device used by this script.
+
+    Resolution order:
+
+    1. If the environment variable ``JUST_INTONATION_MIDI_DEVICE_ID`` is set
+       to an integer, use that device id (must be an output device).
+    2. Otherwise scan outputs whose name contains the substring from
+       ``JUST_INTONATION_MIDI_OUT_NAME`` (default: ``loopbe``, case-insensitive).
+       This matches Windows *LoopBe1* ports ("LoopBe Internal MIDI", etc.).
+    """
+    if 'JUST_INTONATION_MIDI_DEVICE_ID' in os.environ:
+        device_id = int(os.environ['JUST_INTONATION_MIDI_DEVICE_ID'])
+        info = midi.get_device_info(device_id)
+        if info is None:
+            raise RuntimeError(
+                'JUST_INTONATION_MIDI_DEVICE_ID=%s is out of range '
+                '(midi.get_count() == %s).' % (device_id, midi.get_count()))
+        if not info[3]:
+            raise RuntimeError(
+                'JUST_INTONATION_MIDI_DEVICE_ID=%s is not a MIDI output.' % (
+                    device_id,))
+        return device_id
+
+    needle = os.environ.get(
+        'JUST_INTONATION_MIDI_OUT_NAME', 'loopbe').lower()
+    outputs = list(_list_midi_output_devices())
+    for device_id, name in outputs:
+        if needle in name.lower():
+            return device_id
+
+    lines = ['No MIDI output device name contains %r.' % needle,
+             'Install a virtual MIDI cable (see README.md), then either',
+             '  set JUST_INTONATION_MIDI_OUT_NAME to a unique substring of',
+             '  its port name, or set JUST_INTONATION_MIDI_DEVICE_ID to a',
+             '  number from the list below.',
+             '',
+             'Available MIDI *output* devices:']
+    if not outputs:
+        lines.append('  (none — PortMidi sees no writable outputs; on Linux'
+                      ' check ALSA `seq` / `snd_seq` and that pygame was built'
+                      ' with MIDI support.)')
+    else:
+        for device_id, name in outputs:
+            lines.append('  %s: %s' % (device_id, name))
+    raise RuntimeError('\n'.join(lines))
+
 
 rest = 0.5  # seconds
 
+
 def log2(x):
     return math.log(x, 2)
+
 
 def freq_to_MIDI(freq):
     A = 440
     return 12 * log2(freq / A) + 69
 
+
 midi.init()
 
-if 'LoopBe' in midi.get_device_info(3)[1]:
-    try:
-        synth = midi.Output(3)
-    except Exception as e:
-        if 'Invalid device ID' in str(e):
-            synth.close()
-            synth = midi.Output(3)
-        else:
-            raise
-else:
-    raise Exception('Loopback MIDI device not found')
+_output_id = resolve_midi_output_device_id()
+try:
+    synth = midi.Output(_output_id)
+except Exception:
+    midi.quit()
+    raise
 
 channels = 16
 program = 0
+
 
 def play_freq(freq, duration=None, sustain=15):
     """
@@ -83,7 +157,8 @@ def play_freq(freq, duration=None, sustain=15):
         # Prevents synth from choking on all the tails of notes
         # Randomize by 10% so they don't all shut off at once
         rand = random.uniform(0.9, 1.1)
-        Timer(sustain*rand, synth.note_off, (MIDI_note, 0, channel)).start()
+        Timer(sustain * rand, synth.note_off, (MIDI_note, 0, channel)).start()
+
 
 play_freq.channel = 0
 
@@ -158,13 +233,14 @@ def play_seq(pitch, intervals, rest=rest):
         play_freq(root + x)
         time.sleep(rest)
 
+
 pitch = Pitch(110)
 
 # Lydian mode
-lydian = sorted(arange(7)*P5 % P8) + [P8]
+lydian = sorted(arange(7) * P5 % P8) + [P8]
 
 # Locrian mode
-locrian = sorted(arange(7)*P4 % P8) + [P8]
+locrian = sorted(arange(7) * P4 % P8) + [P8]
 
 # play_seq(110, random.sample(locrian, 8))
 
@@ -172,7 +248,7 @@ locrian = sorted(arange(7)*P4 % P8) + [P8]
 # Equal:
 def equal_major():
     synth.set_instrument(program, channel=0)
-    synth.pitch_bend(channel=0)
+    synth.pitch_bend(0, channel=0)
     for note in [57, 61, 64]:
         synth.note_on(note, 127, 0)
         Timer(5, synth.note_off, (note, 0, 0)).start()
@@ -182,6 +258,7 @@ def equal_major():
 #    for note in [57, 61, 64]:
 #        synth.note_on(note, 127, 0)
 #        Timer(5, synth.note_off, (note, 0, 0)).start()
+
 
 def just_major():
     play_freq(Pitch(220), sustain=5)
@@ -195,7 +272,7 @@ def just_major():
 
 def equal_minor():
     synth.set_instrument(program, channel=0)
-    synth.pitch_bend(channel=0)
+    synth.pitch_bend(0, channel=0)
     for note in [57, 60, 64]:
         synth.note_on(note, 127, 0)
         Timer(5, synth.note_off, (note, 0, 0)).start()

--- a/requirements-midi.txt
+++ b/requirements-midi.txt
@@ -1,0 +1,3 @@
+# Optional: for midi_play.py (mido + RtMidi + numpy mode arrays)
+mido[ports-rtmidi]>=1.3
+numpy>=1.19


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces **pygame / PortMidi** in `midi_play.py` with **[mido](https://mido.readthedocs.io/)** and the **[RtMidi](https://www.music.mcgill.ca/~gary/rtmidi/)** backend (`mido[ports-rtmidi]` / `python-rtmidi`), which is the usual stack for dedicated MIDI I/O in Python today. Behavior is unchanged: **per-note channel rotation**, **pitch bend** for sub-semitone tuning (same `frac * 4096` mapping, clamped to **−8192..8191**), **GM drum channel skipped**, `Timer`-based note-offs, and the same **`JUST_INTONATION_MIDI_*`** selection logic (now against `mido.get_output_names()` indices).

## Files

- **`midi_play.py`**: `mido.set_backend('mido.backends.rtmidi')`, `resolve_midi_output_port_name()`, `open_output`, `Message(...)` for all traffic; `atexit` closes the port; clearer error if **RtMidi cannot enumerate** (e.g. Linux without `/dev/snd/seq`).
- **`requirements-midi.txt`**: optional `mido[ports-rtmidi]` + `numpy` for the demo (main package / CI unchanged).
- **`README.md`**: MIDI section updated for mido/RtMidi, `pip install -r requirements-midi.txt`, historical pointer to [pygame PR #394](https://github.com/pygame/pygame/pull/394).

## Notes

- This branch also contains the earlier **README MIDI setup** commit from the same line of work (device env vars, LoopBe / IAC / Linux text). If that landed on `master` separately, rebase this branch onto updated `master` before merge.
- RtMidi may print ALSA warnings to stderr on broken/minimal hosts; the raised **`RuntimeError`** explains the usual Linux fix.

## Verification

- `pytest` — 21 passed (`midi_play` not imported by tests).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c91acb39-acee-4ed2-820c-85d0f7752589"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c91acb39-acee-4ed2-820c-85d0f7752589"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

